### PR TITLE
Fixed README.md for a typo in 'const { notifiy } = useNotification();'

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ export default defineNuxtConfig({
 <!-- page.vue/component.vue -->
 
 <script setup>
-  const { notifiy } = useNotification();
+  const { notify } = useNotification();
 
   function onClick() {
     notify({


### PR DESCRIPTION
`const { notify } = useNotification();

function onClick() {
   notify({
      title: "Title",
      text: "Hello notify!",
   });
}`

There was an type in in line
`const { notifiy } = useNotification();`