### PR TITLE
chore: indicate compatibility with new v4 major

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -13,7 +13,7 @@ export default defineNuxtModule<ModuleOptions>({
     name: PACKAGE_NAME,
     configKey: 'nuxtNotifications',
     compatibility: {
-      nuxt: '^3.0.0'
+      nuxt: '>=3.0.0'
     }
   },
   defaults: {


### PR DESCRIPTION
This updates the module compatibility definition to allow it to be installed on Nuxt v4. (Otherwise Nuxt will indicate the module is incompatible.)