### PR TITLE
feat: add name setting for composable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ export default defineNuxtConfig({
 export default defineNuxtConfig({
   modules: ['nuxt3-notifications'],
   nuxtNotifications: {
-    componentName: 'Foo' // 'foo-bar' or 'FooBar' for components of two or more words
+    componentName: 'Foo', // 'foo-bar' or 'FooBar' for components of two or more words
+    composableName: 'useFoo',
   },
 });
 ```

--- a/docs/content/1.docs/1.introduction/1.getting-started.md
+++ b/docs/content/1.docs/1.introduction/1.getting-started.md
@@ -39,6 +39,7 @@ The module settings can be seen on the page [configuration](/docs/introduction/c
     modules: ['nuxt3-notifications'],
     nuxtNotifications: {
       componentName: 'AppNotifications'
+      composableName: 'useAppNotification',
     }
   })
   ```
@@ -82,9 +83,26 @@ User from any application component
 
 ::code-group
 
-  ```vue [Composition API]
+  ```vue [Composition API (empty config)]
   <script setup>
     const { notify } = useNotification();
+  
+    function onClick() {
+      notify({
+        title: "Title",
+        text: "Hello notify!",
+      });
+    }
+  </script>
+  
+  <template>
+    <button @click="onClick">Show notify</button>
+  </template>
+  ```
+
+  ```vue [Composition API (filled config)]
+  <script setup>
+    const { notify } = useAppNotification();
   
     function onClick() {
       notify({

--- a/docs/content/1.docs/1.introduction/2.configuration.md
+++ b/docs/content/1.docs/1.introduction/2.configuration.md
@@ -6,6 +6,7 @@ Learn how to configure module.
 export default defineAppConfig({
   nuxtNotifications: {
     componentName: 'NuxtNotifications'
+    composableName: 'useNotification'
   }
 })
 ```
@@ -13,6 +14,7 @@ export default defineAppConfig({
 | **Key**                      | **Type**   | **Default**           | **Description**                                                                                      |
 |------------------------------| ---------- | --------------------- | ---------------------------------------------------------------------------------------------------- |
 | `componentName`              | `string`   | NuxtNotifications     | The name of the component that needs to be declared                                                  |
+| `composableName`             | `string`   | useNotification       | The name of the composable that needs to be declared                                                  |
 
 
 ## Learn how customize vue plugin

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -10,6 +10,10 @@ export default defineNuxtConfig({
     /**
      * @description Наименование компонента уведомлений
      */
-    // componentName: 'NuxtNotifications'
+    // componentName: 'NuxtNotifications',
+    /**
+     * @description Наименование composable уведомлений
+     */
+    // composableName: 'useNotification',
   }
 });

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,11 +1,12 @@
 import { fileURLToPath } from 'node:url';
 import { pascalCase } from 'scule';
-import { defineNuxtModule, addPlugin, createResolver, useLogger, addImportsDir, addComponent } from '@nuxt/kit';
+import { defineNuxtModule, addPlugin, createResolver, useLogger, addComponent, addImports } from '@nuxt/kit';
 
 const PACKAGE_NAME = 'nuxt-notifications';
 
 export interface ModuleOptions {
   componentName: string | undefined;
+  composableName: string | undefined;
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -17,7 +18,8 @@ export default defineNuxtModule<ModuleOptions>({
     }
   },
   defaults: {
-    componentName: 'NuxtNotifications'
+    componentName: 'NuxtNotifications',
+    composableName: 'useNotification'
   },
   async setup(options) {
     const logger = useLogger(PACKAGE_NAME);
@@ -31,9 +33,6 @@ export default defineNuxtModule<ModuleOptions>({
 
     const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url));
 
-    // GLOBAL useNotification hook
-    addImportsDir(resolve('./runtime/composables'));
-
     addPlugin({
       src: resolve(runtimeDir, 'plugin')
     });
@@ -44,6 +43,12 @@ export default defineNuxtModule<ModuleOptions>({
       export: 'Notifications',
       global: true
     });
+
+    addImports({
+      name: 'useNotification',
+      as: options.composableName,
+      from: resolve('./runtime/composables/useNotification')
+    })
 
     logger.success('Setup end');
   }


### PR DESCRIPTION
This updates the module settings by adding the ability to change the composable name
```TS
// nuxt.config.ts
nuxtNotifications: {
    componentName: 'NuxtNotifications',
    composableName: 'useNuxt3Notification',
}

// app.vue
import { useNuxt3Notification } from '#imports';

const { notify } = useNuxt3Notification();
```
Demo on [StackBlitz](https://stackblitz.com/edit/nuxt3-notificationscustomize-composable-name-mlgswjz7?file=playground%2Fapp.vue)